### PR TITLE
Fix "Distance Distance" when using setup.ps1

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,3 @@
 SOLUTION=Mod.Template.sln
-ARTIFACTS=Build/Distance Mod Template.zip
+ARTIFACTS=Build/Mod Template.zip
 RELEASE_BODY=This release was automatically generated as part of a GitHub workflow. Please read the repository README for more info.

--- a/Mod.Template/Mod.Template.targets
+++ b/Mod.Template/Mod.Template.targets
@@ -1,5 +1,5 @@
 ﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<PropertyGroup>
-		<ModName>Distance Mod Template</ModName>
+		<ModName>Mod Template</ModName>
 	</PropertyGroup>
 </Project>


### PR DESCRIPTION
In `setup.ps1`, the replace-all for "Mod Template" **-&gt;** $Title replaces instances where "Distance Mod Template" is the original text. $Title is already transformed into "Distance $InputName" before assignment. So in those instances, the output text is *"Distance $Title"* or *"Distance Distance $InputName"*.

This PR fixes two instances where "Distance Mod Template" appears and replaces them with "Mod Template".

Changes have been tested by following the standard protocol for creating a repo from the modified template, to creating a workflow release, to testing the release in Distance.

